### PR TITLE
Add optional ReplyTo field to Email class

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "dotnet test SimpleMail.sln",
+    "build": "dotnet build SimpleMail.sln",
+    "launch": "dotnet run --project SimpleMail.Example"
+  }
+}

--- a/SimpleMail.Example/Program.cs
+++ b/SimpleMail.Example/Program.cs
@@ -33,7 +33,9 @@
                 // Use SSL to encrypt the connection
                 UseSSL = true,
                 // Priority of the email
-                Priority = MimeKit.MessagePriority.Urgent
+                Priority = MimeKit.MessagePriority.Urgent,
+                // Reply-to address
+                ReplyTo = "replyto@example.com"
             };
             // Send the email
             await email.SendAsync().ConfigureAwait(false);

--- a/SimpleMail/Email.cs
+++ b/SimpleMail/Email.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2016 James Craig
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -123,6 +123,12 @@ namespace SimpleMail
         public bool UseSSL { get; set; }
 
         /// <summary>
+        /// Gets or sets the reply-to address.
+        /// </summary>
+        /// <value>The reply-to address.</value>
+        public string ReplyTo { get; set; }
+
+        /// <summary>
         /// Sends this email
         /// </summary>
         public void Send()
@@ -201,6 +207,10 @@ namespace SimpleMail
             SplitRecipients(InternalMessage.To, To);
             SplitRecipients(InternalMessage.Bcc, Bcc);
             SplitRecipients(InternalMessage.Cc, Cc);
+            if (!string.IsNullOrEmpty(ReplyTo))
+            {
+                SplitRecipients(InternalMessage.ReplyTo, ReplyTo);
+            }
             MimeEntity Content = new TextPart(TextFormat.Html) { Text = Body };
             if (Attachments.Count > 0)
             {


### PR DESCRIPTION
feat: Add a `ReplyTo` field to the `Email` class and update the `SetupMessage` method to include the `ReplyTo` address in the email.

* **SimpleMail/Email.cs**
  - Add `ReplyTo` property to the `Email` class.
  - Update `SetupMessage` method to include `ReplyTo` in `MimeMessage`.

* **SimpleMail.Example/Program.cs**
  - Add example usage of `ReplyTo` field in the `Email` instance.

* **.devcontainer/devcontainer.json**
  - Add devcontainer configuration file with tasks for testing, building, and launching the project.

